### PR TITLE
[G2M] API CRUD catchup/grooming

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
-import { Router } from 'itty-router'
-import { withContent } from 'itty-router-extras'
+const { Router } = require('itty-router')
+const { withContent } = require('itty-router-extras')
 
 const {
   root,
-  getUser,
   listTeams,
   createTeam,
   listProjects,
@@ -14,42 +13,44 @@ const {
   listAll,
   getToken,
   getEnv,
+  withRequiredName,
 } = require('./handlers')
-const { corsHeaders } = require('./modules/utils')
+const { corsHeaders, respondJSON } = require('./modules/utils')
+const { withRequireUser } = require('./modules/auth')
 
 const router = Router()
 
-const withCors = (request) => {
+const withCors = (_) => {
   // TODO: could check in greater detail
   return new Response(null, { headers: { ...corsHeaders } })
 }
 router.options('*', withCors)
 
 // UI
-router.get('/all', listAll)
+router.get('/all', withRequireUser, listAll)
 
-router.get('/teams', listTeams)
+router.get('/teams', withRequireUser, listTeams)
 // router.get('/team', getTeam)
-router.post('/team', withContent, createTeam)
+router.post('/team', withContent, withRequiredName('team'), withRequireUser, createTeam)
 // router.put('/team/update', updateTeam)
 // router.delete('/team/delete', deleteTeam)
 
-router.get('/user', getUser)
-router.get('/users', listUsers)
+router.get('/user', withRequireUser, ({ user }) => respondJSON(user))
+router.get('/users', withRequireUser, listUsers)
 // router.put('/user/team', addUserToTeam)
 // router.put('/user/admin', addUserToAdmin)
 // router.delete('/user/team', removeUserFromTeam)
 // router.delete('/user/admin', removeUserFromAdmin)
 
-router.get('/projects', listProjects)
+router.get('/projects', withRequireUser, listProjects)
 // router.get('/project', getProject)
-router.put('/project', withContent, createProject)
+router.put('/project', withContent, withRequiredName('project'), withRequireUser, createProject)
 // router.put('/project/update', updateProject)
 // router.delete('/project/delete', deleteProject)
 
-router.get('/stages', listStages)
+router.get('/stages', withRequireUser, listStages)
 // router.get('/stage', getStage)
-router.put('/stage', withContent, createStage)
+router.put('/stage', withContent, withRequireUser('stage'), withRequireUser, createStage)
 // router.put('/stage/update', updateStage)
 // router.delete('/stage/delete', deleteStage)
 

--- a/modules/auth.js
+++ b/modules/auth.js
@@ -1,6 +1,6 @@
 const jwt = require('jsonwebtoken')
 
-const { extractParams, parseProj, HTTPError } = require('./utils')
+const { extractParams, parseProj, HTTPError, respondError } = require('./utils')
 const { getKVUser } = require('./users')
 
 // process.env is not avail in workers, direct access like KV namespaces and secrets
@@ -51,4 +51,14 @@ module.exports.parseJWT = async ({ url, headers }) => {
     throw new HTTPError('Invalid portunus-jwt: no project access', 400)
   }
   return { user, team, p, stage }
+}
+
+module.exports.withRequireUser = async (req) => {
+  const { headers } = req
+  try {
+    const access = this.verifyJWT(headers)
+    req.user = await this.verifyUser(access)
+  } catch (err) {
+    return respondError(err)
+  }
 }


### PR DESCRIPTION
catching up with the latest API routes development, while doing a bit of simplification and grooming

- `listAll` simplifications around `Promise.all` with direct promises (as `deta.Base.<action>` already returns promises)
- `listTeams` simplification (similar as ^) and optimization with one `await Promise.all`
- `createStage` fix due to lack of import of interface function
- add `withRequiredUser` middleware to check and populate `user` object
- add `withRequiredName` higher order function that takes a key (such as `project`) and optional required name length (default to 3) that returns a itty-router middleware
- fix `listStage` fetch `project` field composition
- consistent module import for itty router and extra using `require`