### PR TITLE
Portunus worker update ci cd

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,20 +1,45 @@
 name: Publish Cloudflare Workers - dev environment
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - master
-      - main # for future use
+      - main
     tags:
       - 'dev-*' # release tag for on-demand deployment
+    paths-ignore:
+      - "README.md"
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: set node version according to .nvmrc
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - run: npm ci
+
       - name: Publish
-        uses: cloudflare/wrangler-action@1.3.0
+        uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
+          wranglerVersion: '3.2.0'
+          command: deploy --env dev
+          environment: dev
+          secrets: |
+            MAIL_PASS
+            TOKEN_SECRET
+            DETA_KEY
+        env:
+          # Sendgrid 'dev'
+          MAIL_PASS: ${{ secrets.MAIL_PASS_DEV }}
+          # JWT token secret 'dev'
+          TOKEN_SECRET: ${{ secrets.TOKEN_SECRET_DEV }}
+          # Deta 'dev' collection
+          DETA_KEY: ${{ secrets.DETA_KEY_DEV }}

--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -4,15 +4,41 @@ on:
   push:
     tags:
       - 'prod-*' # release tag for on-demand deployment
+    paths-ignore:
+      - "README.md"
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     name: Deploy
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: set node version according to .nvmrc
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - run: npm ci
+
       - name: Publish
-        uses: cloudflare/wrangler-action@1.3.0
+        uses: cloudflare/wrangler-action@2.0.0
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
+          wranglerVersion: '3.2.0'
+          preCommands: npm ci
+          command: deploy --env production
           environment: production
+          secrets: |
+            MAIL_PASS
+            TOKEN_SECRET
+            DETA_KEY
+        env:
+          # Sendgrid 'prod'
+          MAIL_PASS: ${{ secrets.MAIL_PASS_PROD }}
+          # JWT token secret 'prod'
+          TOKEN_SECRET: ${{ secrets.TOKEN_SECRET_PROD }}
+          # Deta 'prod' collection
+          DETA_KEY: ${{ secrets.DETA_KEY_PROD }}
+      

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,27 +1,24 @@
 name = "portunus-worker"
-type = "webpack"
 account_id = "ae0efcc5352882cf6f1ac3a3a40645ba"
-workers_dev = true
-route = ""
-zone_id = ""
-compatibility_date = "2021-11-29"
-kv_namespaces = [
-    # USERS_DEV (id and preview_id)
-    { binding = "USERS", id = "36df6ebcc3d6453e81094dd5730e30ee", preview_id = "36df6ebcc3d6453e81094dd5730e30ee" },
-    # KV_DEV (id), KV_PREVIEW (preview_id: 09f9d1a399dc4032a5d7f561e577872a)
-    { binding = "KV", id = "99aca84159ad4e7eb3f3048611680dd8", preview_id = "99aca84159ad4e7eb3f3048611680dd8" }
-]
-
-# [secrets]
-# TOKEN_SECRET
-# MAIL_PASS
-# DETA_KEY
-# DETA_ID
+workers_dev = false
+main = "index.js"
+compatibility_date = "2023-07-10"
+node_compat = true
 
 [env.production]
-zone_id = "5c9fc9248d20a5ed0b6b1f1a155ded67"
-route = "cli.mindswire.com/*"
 kv_namespaces = [
     { binding = "KV", id = "ff28952fe8204640a5e7c55d390724ff" },
     { binding = "USERS", id = "b4bc01b41e0643d88ffc52a348f721ce" }
+]
+routes = [
+	{ pattern = "cli.mindswire.com/*", zone_name = "mindswire.com" }
+]
+
+[env.dev]
+kv_namespaces = [
+    { binding = "KV", preview_id = "99aca84159ad4e7eb3f3048611680dd8", id = "99aca84159ad4e7eb3f3048611680dd8" },
+    { binding = "USERS", preview_id = "36df6ebcc3d6453e81094dd5730e30ee", id = "36df6ebcc3d6453e81094dd5730e30ee" }
+]
+routes = [
+	{ pattern = "clidev.mindswire.com/*", zone_name = "mindswire.com" }
 ]


### PR DESCRIPTION
Changes:
- Adds support for wrangler `3.2.0`
- Separate `dev` and `prod` workers

The following secrets should be passed via github repo secrets instead of passing these via cf workers dashboard:
- `MAIL_PASS_PROD`
- `MAIL_PASS_DEV`
- `TOKEN_SECRET_PROD`
- `TOKEN_SECRET_DEV`
- `DETA_KEY_PROD`
- `DETA_KEY_DEV`
- `CF_API_TOKEN `

For `CF_API_TOKEN` the following preset will be enough:

![image](https://github.com/portunus-dev/portunus-worker/assets/11252951/d9c5e5a4-357b-4d60-a40b-63f52d38e288)
